### PR TITLE
Feat/info file

### DIFF
--- a/internal/app/tempr/flags/flags.go
+++ b/internal/app/tempr/flags/flags.go
@@ -4,8 +4,8 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-var helpPtr *bool
-var logLevelPtr *int
+var LogLevelPtr *int
+var DisableInfoFilePtr *bool
 
 func Declare() {
 	// log-level
@@ -17,10 +17,15 @@ func Declare() {
 	3: Program information
 	4: Debug information
 `)
+
+	disableInfoFilePtr = flag.Bool("no-info-file", false,
+		"Disables the generation of the '.tempr' info file")
 }
 
 func Handle() {
 	flag.Parse()
+	// TODO: ADD STYLING
 	//vvv  INFO: Flag handlers that should be executed immediately vvv
 	handleLogLevel(logLevelPtr)
+	handleInfoFileCreation(disableInfoFilePtr)
 }

--- a/internal/app/tempr/flags/flags.go
+++ b/internal/app/tempr/flags/flags.go
@@ -4,7 +4,7 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-var LogLevelPtr *int
+var logLevelPtr *int
 var DisableInfoFilePtr *bool
 
 func Declare() {
@@ -18,7 +18,7 @@ func Declare() {
 	4: Debug information
 `)
 
-	disableInfoFilePtr = flag.Bool("no-info-file", false,
+	DisableInfoFilePtr = flag.Bool("no-info-file", false,
 		"Disables the generation of the '.tempr' info file")
 }
 
@@ -27,5 +27,5 @@ func Handle() {
 	// TODO: ADD STYLING
 	//vvv  INFO: Flag handlers that should be executed immediately vvv
 	handleLogLevel(logLevelPtr)
-	handleInfoFileCreation(disableInfoFilePtr)
+	handleInfoFileCreation(DisableInfoFilePtr)
 }

--- a/internal/app/tempr/flags/log.go
+++ b/internal/app/tempr/flags/log.go
@@ -17,4 +17,5 @@ func handleLogLevel(level *int) {
 	}
 
 	logger.SetLevel(levelMap[*level])
+	tempr.Logger().Debugf("Loglevel: %d", *level)
 }

--- a/internal/app/tempr/flags/templating.go
+++ b/internal/app/tempr/flags/templating.go
@@ -1,0 +1,10 @@
+package flags
+
+import (
+	"github.com/lolmerkat/tempr/internal/app/tempr"
+)
+
+func handleInfoFileCreation(disableInfoFile *bool) {
+	logger := tempr.Logger()
+	logger.Debugf("Info file creation: %t", *disableInfoFile)
+}

--- a/internal/app/tempr/templating/types/template.go
+++ b/internal/app/tempr/templating/types/template.go
@@ -135,7 +135,7 @@ func (t Template) CreateInfoFile(path string, logger *log.Logger) error {
 
 	// create file
 	filePath := fmt.Sprintf("%s/.tempr", path)
-	file, err := os.Open(filePath)
+	file, err := os.Create(filePath)
 	if err != nil {
 		logger.Warnf("Error creating info file: %v", err)
 		return err

--- a/internal/app/tempr/templating/types/template.go
+++ b/internal/app/tempr/templating/types/template.go
@@ -107,11 +107,22 @@ func (t Template) GenerateInfoYaml(logger *log.Logger) ([]byte, error) {
 		Author    string      `yaml:"author,omitempty"`
 		Version   string      `yaml:"version,omitempty"`
 	}
+	infoFileData.Name = t.Name
+	infoFileData.Author = t.Author
+	infoFileData.Version = t.Version
+
 	commentMap := yaml.CommentMap {
 		"$": []*yaml.Comment {
 			{
 				Texts: []string{
-					"This project structure was created using github.com/lolmerkat/tempr",
+					" This project structure was created using github.com/lolmerkat/tempr",
+					" This file contains information about the template used.",
+					" ",
+					" To support the project, keep this file in your codebase",
+					" (and potentially commit it to your repository).",
+					" If you don't want to, that's fine.",
+					" Thank you for using my tool in any way.",
+					" ",
 				},
 				Position: yaml.CommentHeadPosition,
 			},

--- a/internal/app/tempr/templating/types/template.go
+++ b/internal/app/tempr/templating/types/template.go
@@ -120,7 +120,7 @@ func (t Template) GenerateInfoYaml(logger *log.Logger) ([]byte, error) {
 
 	bytes, err := yaml.MarshalWithOptions(infoFileData, yaml.WithComment(commentMap))
 	if err != nil {
-		log.Warnf("Error creating info file yaml bytes: %v", err)
+		logger.Warnf("Error creating info file yaml bytes: %v", err)
 		return nil, err
 	}
 	return bytes, nil
@@ -137,7 +137,7 @@ func (t Template) CreateInfoFile(path string, logger *log.Logger) error {
 	filePath := fmt.Sprintf("%s/.tempr", path)
 	file, err := os.Open(filePath)
 	if err != nil {
-		log.Warnf("Error creating info file: %v", err)
+		logger.Warnf("Error creating info file: %v", err)
 		return err
 	}
 	defer file.Close()
@@ -145,7 +145,7 @@ func (t Template) CreateInfoFile(path string, logger *log.Logger) error {
 	// write bytes
 	n, err := file.Write(infoFileBytes)
 	if err != nil {
-		log.Warnf("Error writing info file: %v", err)
+		logger.Warnf("Error writing info file: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
This pull request introduces a new feature to optionally disable the creation of a `.tempr` info file, alongside improvements to logging and templating functionality. Key changes include the addition of a new flag, handling logic for the flag, and methods to generate and manage the `.tempr` info file.

### New Feature: Optional `.tempr` Info File Creation

* **Added a new flag `--no-info-file`**: This flag allows users to disable the creation of the `.tempr` info file. The flag is defined in `internal/app/tempr/flags/flags.go` and is handled by the `handleInfoFileCreation` function. [[1]](diffhunk://#diff-4aee06c92758a0d47e586640e6f7b32059683c20548694459a1c4dbbaa104dd5L7-R8) [[2]](diffhunk://#diff-4aee06c92758a0d47e586640e6f7b32059683c20548694459a1c4dbbaa104dd5R20-R30) [[3]](diffhunk://#diff-9de3d02e5467e14213e4b9f169e513ea3a698f6e40b2b9f70c4747a5f819f691R1-R10)
* **Integrated `.tempr` info file logic into the templating process**: The `Template` struct now includes methods `GenerateInfoYaml` and `CreateInfoFile` to generate and write the `.tempr` info file. The `Expand` method was updated to conditionally create the file based on the flag. [[1]](diffhunk://#diff-66eee3218a83c6ef3df4d5da59ad2a0bc3564564c9723927c0cc3a89aac86497R35-R38) [[2]](diffhunk://#diff-66eee3218a83c6ef3df4d5da59ad2a0bc3564564c9723927c0cc3a89aac86497R103-R172)

### Codebase Enhancements

* **Improved modularity**: Introduced a new `handleInfoFileCreation` function in `internal/app/tempr/flags/templating.go` to handle the `.tempr` info file logic, improving separation of concerns.
* **Updated imports to reflect new dependencies**: Added the `flags` package import to `internal/app/tempr/templating/types/template.go` to enable access to the new flag.